### PR TITLE
Add Support for Ignoring Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A `ParsableClass` attribute which is applied to your class object can be provide
 5. **ExampleText** - Example content that will be included on help screens.  
 6. **FooterText** - Footer content that will be included on help screens.  
 7. **AllowedPrefixes** - The allowed parameter prefix characters. Default is '-' and '/'.  
+8. **IgnoreUnknowns** - Ignore any unknown arguments. Default is `false`.
 
 ### Property level
 A `ParsableArgument` attribute which is applied to properties on your class object can be provided with the following properties:  

--- a/src/CliParse.Test/CliParse.Tests.csproj
+++ b/src/CliParse.Test/CliParse.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="ParsableObjects\CommandLineArgs.cs" />
     <Compile Include="ParsableObjects\AnalysisOptions.cs" />
     <Compile Include="ParsableObjects\ExampleParsable.cs" />
+    <Compile Include="ParsableObjects\IgnoreUnkownArgs.cs" />
     <Compile Include="ParsableObjects\RequiredCli.cs" />
     <Compile Include="ParsableObjects\SimpleCli.cs" />
     <Compile Include="ParsableTests.cs" />

--- a/src/CliParse.Test/InfoTests.cs
+++ b/src/CliParse.Test/InfoTests.cs
@@ -189,6 +189,10 @@ The following argument prefix characters can be used: '-','/'
         Outputs a list of the named patterns from the 
         default.tdg-patterns file.
         [Optional], Default:'False'
+        
+    --impliedDefault,     
+        Implied first position. Default is 1
+        [Optional], Default:'1'
 ";
 
             var actual = simple.GetUsage();

--- a/src/CliParse.Test/ParsableObjects/CommandLineArgs.cs
+++ b/src/CliParse.Test/ParsableObjects/CommandLineArgs.cs
@@ -39,6 +39,9 @@ namespace CliParse.Tests.ParsableObjects
         [ParsableArgument("listnamedpatterns", ShortName = 'l', DefaultValue = false, Description = "Outputs a list of the named patterns from the default.tdg-patterns file.", Required = false)]
         public bool ListNamedPatterns { get; set; }
 
+        [ParsableArgument("impliedDefault", DefaultValue = 1, Description = "Implied first position. Default is 1",ImpliedPosition = 1, Required = false)]
+        public int ImpliedDefault { get; set; }
+
         public string GetUsage()
         {
             //var asm = Assembly.GetExecutingAssembly();

--- a/src/CliParse.Test/ParsableObjects/IgnoreUnkownArgs.cs
+++ b/src/CliParse.Test/ParsableObjects/IgnoreUnkownArgs.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CliParse.Tests.ParsableObjects
+{
+    [ParsableClass("IgnoreUnknowns", IgnoreUnknowns = true)]
+    public class IgnoreUnkownArgs : Parsable
+    {
+        /// <summary>
+        /// 'd' RequiredField
+        /// </summary>
+        [ParsableArgument("RequiredField", ShortName = 'd', Required = true)]
+        public string RequiredField
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/CliParse.Test/ParsableTests.cs
+++ b/src/CliParse.Test/ParsableTests.cs
@@ -203,6 +203,19 @@ namespace CliParse.Tests
 
         [TestCategory("Parsing")]
         [TestMethod]
+        public void required_and_ignore_unknown_property_checking()
+        {
+            var args = NativeMethods.CommandLineToArgs("-d c:\\Temp");
+            var simple = new IgnoreUnkownArgs();
+            var result = simple.CliParse(args);
+
+            Assert.AreEqual(true, result.Successful);
+            Assert.AreEqual(0, result.CliParseMessages.ToList().Count);
+            Assert.AreEqual(false, result.ShowHelp);
+        }
+
+        [TestCategory("Parsing")]
+        [TestMethod]
         public void sets_showhelp_to_false_when_no_arguments_supplied_and_showhelpwhennoargumentsprovided_is_false()
         {
             var args = NativeMethods.CommandLineToArgs("");

--- a/src/CliParse.Test/ParsableTests.cs
+++ b/src/CliParse.Test/ParsableTests.cs
@@ -88,6 +88,20 @@ namespace CliParse.Tests
 
         [TestCategory("Parsing")]
         [TestMethod]
+        public void can_set_implied_defaulted_values()
+        {
+            var args = NativeMethods.CommandLineToArgs("100");
+            var simple = new CommandLineArgs();
+            var result = simple.CliParse(args);
+
+            Assert.AreEqual(true, result.Successful,"Successful");
+            Assert.AreEqual(0, result.CliParseMessages.ToList().Count);
+            Assert.AreEqual(false, result.ShowHelp);
+            Assert.AreEqual(100, simple.ImpliedDefault);
+        }
+
+        [TestCategory("Parsing")]
+        [TestMethod]
         public void can_parse_int_arguments_by_short_name()
         {
             var args = NativeMethods.CommandLineToArgs("/f 1");

--- a/src/CliParse/ParsableClass.cs
+++ b/src/CliParse/ParsableClass.cs
@@ -45,6 +45,12 @@ namespace CliParse
         public bool ShowHelpWhenNoArgumentsProvided { get; set; }
 
         /// <summary>
+        /// Ingore unknown parameters
+        /// </summary>
+        /// <remarks>Default is false</remarks>
+        public bool IgnoreUnknowns { get; set; }
+
+        /// <summary>
         /// A parsable class attribute.
         /// </summary>
         /// <param name="title">The title used for help content</param>

--- a/src/CliParse/Parser.cs
+++ b/src/CliParse/Parser.cs
@@ -43,6 +43,7 @@ namespace CliParse
 
             var parsableClass = Helper.GetObjectAttribute(parsable, typeof(ParsableClassAttribute)) as ParsableClassAttribute;
             var allowedPrefixes = GetParsableClassAllowedPrefixs(parsableClass);
+            var ignoreUnknowns = parsableClass != null && parsableClass.IgnoreUnknowns;
 
             var tokens = Tokenizer.Tokenize(args, allowedPrefixes).ToList();
             result.ShowHelp = tokens.Any(token=>IsHelpToken(token, parsable));
@@ -99,7 +100,7 @@ namespace CliParse
             }
 
             // unknown/unused aruments
-            if (!result.ShowHelp)
+            if (!result.ShowHelp && !ignoreUnknowns)
             {
                 tokens.Where(x => !x.Taken)
                     .ToList()


### PR DESCRIPTION
My project called for a case where arbitrary arguments could be passed. I've added a property to the `ParsableClassAttribute` called `IgnoreUnknowns`. 1 additional test was added.
